### PR TITLE
Add OpenCV with CMake and vcpkg

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.10)
+set(CMAKE_TOOLCHAIN_FILE "${CMAKE_SOURCE_DIR}/vcpkg/scripts/buildsystems/vcpkg.cmake" CACHE STRING "Vcpkg toolchain file")
+project(OpenCVExample)
+
+find_package(OpenCV REQUIRED)
+
+add_executable(OpenCVExample main.cpp)
+
+target_link_libraries(OpenCVExample ${OpenCV_LIBS})

--- a/main.cpp
+++ b/main.cpp
@@ -1,0 +1,12 @@
+#include <opencv2/opencv.hpp>
+
+int main() {
+    cv::Mat image = cv::imread("example.jpg");
+    if (image.empty()) {
+        std::cerr << "Could not open or find the image" << std::endl;
+        return -1;
+    }
+    cv::imshow("Display window", image);
+    cv::waitKey(0);
+    return 0;
+}


### PR DESCRIPTION
Add CMake configuration and main.cpp for OpenCV project setup.

* **CMakeLists.txt**
  - Set minimum required version of CMake to 3.10.
  - Configure vcpkg toolchain file.
  - Define project name as OpenCVExample.
  - Locate OpenCV package.
  - Add executable target OpenCVExample.
  - Link OpenCV libraries to the target.

* **main.cpp**
  - Include OpenCV header.
  - Implement main function to read and display an image using OpenCV.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ehlde/cpp_npu/pull/1?shareId=53c2e3f1-b403-4c19-aff3-49ba5090c5be).